### PR TITLE
feat: asset partition row count

### DIFF
--- a/examples/io/psql.py
+++ b/examples/io/psql.py
@@ -1,3 +1,5 @@
+import datetime as dt
+from pprint import pp
 from typing import Any
 
 import interloper as il
@@ -12,22 +14,26 @@ io = PostgresIO(
     password="postgres",
 )
 
+partitioning = il.TimePartitionConfig(column="date")
 
-@il.asset(io=io)
-def a() -> list[dict[str, Any]]:
+
+@il.asset(io=io, partitioning=partitioning)
+def a(context: il.ExecutionContext) -> list[dict[str, Any]]:
     return [
-        {"id": 1, "name": "Alice"},
-        {"id": 2, "name": "Bob"},
+        {"date": context.partition_date, "value": 1},
+        {"date": context.partition_date, "value": 2},
     ]
 
 
-@il.asset(io=io)
-def b(a: list[dict[str, Any]]) -> list[dict[str, Any]]:
+@il.asset(io=io, partitioning=partitioning)
+def b(context: il.ExecutionContext, a: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [
-        {"id": 3, "name": "Charlie"},
-        {"id": 4, "name": "David"},
+        {"date": context.partition_date, "value": a[0]["value"] + 2},
+        {"date": context.partition_date, "value": a[1]["value"] + 2},
     ]
 
 
 dag = il.DAG(a, b)
-dag.materialize()
+dag.backfill(il.TimePartitionWindow(start=dt.date(2025, 1, 1), end=dt.date(2025, 1, 7)))
+
+pp(b().partition_row_counts())

--- a/packages/interloper-google-cloud/src/interloper_google_cloud/io/bigquery.py
+++ b/packages/interloper-google-cloud/src/interloper_google_cloud/io/bigquery.py
@@ -279,6 +279,38 @@ class BigQueryIO(DatabaseIO):
         return [dict(row) for row in rows]
 
     # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def _count_by_partition(
+        self, table: str, schema: str | None, column: str,
+    ) -> dict[str, int]:
+        """Return row counts grouped by partition column via BigQuery SQL.
+
+        Args:
+            table: Target table name.
+            schema: Database schema (dataset).
+            column: Column to group by.
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+
+        Raises:
+            TableNotFoundError: If the table does not exist.
+        """
+        if not self._table_exists(table, schema):
+            ref = self._table_ref(table, schema)
+            raise TableNotFoundError(f"Table '{ref}' does not exist. Has the asset been materialized?")
+
+        ref = self._table_ref(table, schema)
+        query = (
+            f"SELECT CAST(`{column}` AS STRING) AS partition_value, "
+            f"COUNT(*) AS cnt FROM `{ref}` GROUP BY 1"
+        )
+        rows = self._client.query(query).result()
+        return {row["partition_value"]: row["cnt"] for row in rows}
+
+    # ------------------------------------------------------------------
     # Serialization
     # ------------------------------------------------------------------
 

--- a/packages/interloper-sql/src/interloper_sql/io/base.py
+++ b/packages/interloper-sql/src/interloper_sql/io/base.py
@@ -243,6 +243,35 @@ class SqlIO(DatabaseIO):
             return [dict(row._mapping) for row in result]
 
     # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def _count_by_partition(
+        self, table: str, schema: str | None, column: str,
+    ) -> dict[str, int]:
+        """Return row counts grouped by partition column via SQL ``GROUP BY``.
+
+        Args:
+            table: Target table name
+            schema: Database schema
+            column: Column to group by
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+
+        Raises:
+            TableNotFoundError: If the table does not exist.
+        """
+        from sqlalchemy import func
+
+        sa_table = self._require_table(table, schema)
+        col = sa_table.c[column]
+        stmt = sa_table.select().with_only_columns(col, func.count()).group_by(col)
+        with self._engine.connect() as conn:
+            result = conn.execute(stmt)
+            return {str(row[0]): row[1] for row in result}
+
+    # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 

--- a/packages/interloper/src/interloper/assets/base.py
+++ b/packages/interloper/src/interloper/assets/base.py
@@ -506,6 +506,59 @@ class Asset(Serializable[AssetSpec]):
 
         return kwargs
 
+    def _resolve_io(self, io_key: str | None = None) -> IO:
+        """Resolve a single IO from this asset.
+
+        Args:
+            io_key: For multi-IO assets, the key identifying which IO to use.
+                When ``None``, uses :attr:`default_io_key` or the first entry.
+
+        Returns:
+            The resolved IO instance.
+
+        Raises:
+            ConfigError: If *io_key* is not found or no IO is configured.
+        """
+        if isinstance(self.io, dict):
+            if io_key is not None:
+                if io_key not in self.io:
+                    raise ConfigError(
+                        f"IO key '{io_key}' not found on asset '{self.name}'. Available keys: {sorted(self.io.keys())}"
+                    )
+                return self.io[io_key]
+            if self.default_io_key is not None and self.default_io_key in self.io:
+                return self.io[self.default_io_key]
+            return next(iter(self.io.values()))
+
+        if self.io is None:
+            raise ConfigError(f"Asset '{self.name}' has no IO configured.")
+
+        return self.io
+
+    def partition_row_counts(self, *, io_key: str | None = None) -> dict[str, int]:
+        """Return row counts grouped by this asset's partition column.
+
+        Delegates to :meth:`IO.partition_row_counts` using the resolved IO.
+
+        Args:
+            io_key: For multi-IO assets, the IO key to query.
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+
+        Raises:
+            PartitionError: If this asset is not partitioned.
+        """
+        if self.partitioning is None:
+            raise PartitionError(
+                f"Asset '{self.name}' is not partitioned. "
+                "Cannot compute partition row counts without a partition column."
+            )
+
+        io = self._resolve_io(io_key)
+        context = IOContext(asset=self)
+        return io.partition_row_counts(context)
+
     def _validate_schema(self, data: Any) -> None:
         """Validate data against schema.
 

--- a/packages/interloper/src/interloper/dag/base.py
+++ b/packages/interloper/src/interloper/dag/base.py
@@ -1,5 +1,7 @@
 """Directed Acyclic Graph for asset execution."""
 
+from __future__ import annotations
+
 import inspect
 from typing import TYPE_CHECKING
 
@@ -13,6 +15,7 @@ from interloper.serialization.dag import DAGSpec
 from interloper.source.base import Source, SourceDefinition
 
 if TYPE_CHECKING:
+    from interloper.backfillers.results import BackfillResult
     from interloper.runners.state import RunState
 
 
@@ -306,6 +309,20 @@ class DAG(Serializable):
         runner = MultiThreadRunner()
         return runner.run(dag=self, partition_or_window=partition_or_window)
 
+    def backfill(
+        self,
+        partition_or_window: Partition | PartitionWindow | None = None,
+    ) -> BackfillResult:
+        """Execute all assets in dependency order using a default ``SerialBackfiller``.
+
+        Returns:
+            The result of the DAG execution.
+        """
+        from interloper.backfillers.serial import SerialBackfiller
+
+        backfiller = SerialBackfiller()
+        return backfiller.backfill(dag=self, partition_or_window=partition_or_window)
+
     def get_predecessors(self, asset_key: AssetInstanceKey) -> list[AssetInstanceKey]:
         """Return upstream asset keys (dependencies) for the given asset.
 
@@ -326,7 +343,7 @@ class DAG(Serializable):
             raise AssetNotFoundError(f"Asset '{asset_key}' not found in DAG")
         return self.successors.get(asset_key, [])
 
-    def mini_dag(self, asset_key: AssetInstanceKey) -> "DAG":
+    def mini_dag(self, asset_key: AssetInstanceKey) -> DAG:
         """Create a mini-DAG with the target asset and its immediate parents.
 
         Parents are included but marked as non-materializable so only the
@@ -351,7 +368,7 @@ class DAG(Serializable):
         assets.append(target)
         return DAG(*assets)
 
-    def copy(self) -> "DAG":
+    def copy(self) -> DAG:
         """Clone the DAG.
 
         Returns:
@@ -368,7 +385,7 @@ class DAG(Serializable):
         return DAGSpec(assets=[asset.to_spec() for asset in self.assets])
 
     @classmethod
-    def from_failed_state(cls, state: "RunState") -> "DAG":
+    def from_failed_state(cls, state: RunState) -> DAG:
         """Return a DAG marking completed assets as non-materializable.
 
         All assets that were COMPLETED in the provided state are set to

--- a/packages/interloper/src/interloper/io/base.py
+++ b/packages/interloper/src/interloper/io/base.py
@@ -53,5 +53,21 @@ class IO(Serializable):
         """
 
     @abstractmethod
+    def partition_row_counts(self, context: IOContext) -> dict[str, int]:
+        """Return row counts grouped by the asset's partition column.
+
+        The partition column is read from ``context.asset.partitioning.column``.
+        Each key in the returned dict is the string representation of a partition
+        value; each value is the number of rows in that partition.
+
+        Args:
+            context: IO context (uses ``asset.name``, ``asset.dataset``,
+                and ``asset.partitioning``).
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+        """
+
+    @abstractmethod
     def to_spec(self) -> IOSpec:
         """Convert to serializable spec."""

--- a/packages/interloper/src/interloper/io/database.py
+++ b/packages/interloper/src/interloper/io/database.py
@@ -180,6 +180,44 @@ class DatabaseIO(IO):
         """
 
     # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _count_by_partition(
+        self, table: str, schema: str | None, column: str,
+    ) -> dict[str, int]:
+        """Return row counts grouped by the values of the given column.
+
+        Args:
+            table: Target table name (from ``asset.name``)
+            schema: Database schema (from ``asset.dataset``)
+            column: Column to group by.
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+        """
+
+    def partition_row_counts(self, context: IOContext) -> dict[str, int]:
+        """Return row counts grouped by the asset's partition column.
+
+        Delegates to :meth:`_count_by_partition` using the table, schema, and
+        partition column extracted from the context.
+
+        Args:
+            context: IO context with asset and partition information.
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+        """
+        assert context.asset.partitioning is not None
+        return self._count_by_partition(
+            context.asset.name,
+            context.asset.dataset,
+            context.asset.partitioning.column,
+        )
+
+    # ------------------------------------------------------------------
     # Data conversion
     # ------------------------------------------------------------------
 

--- a/packages/interloper/src/interloper/io/file.py
+++ b/packages/interloper/src/interloper/io/file.py
@@ -110,6 +110,37 @@ class FileIO(IO):
             with file_path.open("rb") as f:
                 return pickle.load(f)
 
+    def partition_row_counts(self, context: IOContext) -> dict[str, int]:
+        """Return row counts grouped by partition from the filesystem.
+
+        Scans partition subdirectories (``{column}={value}/data.pkl``),
+        unpickles each file, and counts items (``len(data)`` for lists,
+        ``1`` otherwise).
+
+        Args:
+            context: IO context with asset and partition information.
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+        """
+        assert context.asset.partitioning is not None
+        column = context.asset.partitioning.column
+        base_path = Path(self.base_path) / (context.asset.dataset if context.asset.dataset else "") / context.asset.name
+
+        counts: dict[str, int] = {}
+        if not base_path.exists():
+            return counts
+
+        for entry in sorted(base_path.iterdir()):
+            if entry.is_dir() and entry.name.startswith(f"{column}="):
+                partition_value = entry.name.split("=", 1)[1]
+                data_file = entry / "data.pkl"
+                if data_file.exists():
+                    with data_file.open("rb") as f:
+                        data = pickle.load(f)
+                    counts[partition_value] = len(data) if isinstance(data, list) else 1
+        return counts
+
     def to_spec(self) -> IOSpec:
         """Convert to a serializable spec.
 

--- a/packages/interloper/src/interloper/io/memory.py
+++ b/packages/interloper/src/interloper/io/memory.py
@@ -107,6 +107,31 @@ class MemoryIO(IO):
 
         return "/".join(parts)
 
+    def partition_row_counts(self, context: IOContext) -> dict[str, int]:
+        """Return row counts grouped by partition from in-memory storage.
+
+        Scans ``_storage`` keys matching the asset and partition column prefix,
+        counts items in each stored value (``len(data)`` for lists, ``1``
+        otherwise).
+
+        Args:
+            context: IO context with asset and partition information.
+
+        Returns:
+            Mapping from partition value (as string) to row count.
+        """
+        assert context.asset.partitioning is not None
+        column = context.asset.partitioning.column
+        prefix = self._build_key(context.asset.name, context.asset.dataset, None, None)
+        partition_prefix = f"{prefix}/{column}="
+
+        counts: dict[str, int] = {}
+        for key, data in self._storage.items():
+            if key.startswith(partition_prefix):
+                partition_value = key[len(partition_prefix):]
+                counts[partition_value] = len(data) if isinstance(data, list) else 1
+        return counts
+
     def to_spec(self) -> IOSpec:
         """Convert to a serializable spec.
 

--- a/packages/interloper/tests/io/test_database.py
+++ b/packages/interloper/tests/io/test_database.py
@@ -37,6 +37,10 @@ class StubDatabaseIO(DatabaseIO):
         self.calls.append(("select_partition", table, schema, column, value))
         return [{"v": 1}]
 
+    def _count_by_partition(self, table, schema, column):
+        self.calls.append(("count_by_partition", table, schema, column))
+        return {}
+
     def to_spec(self):
         pass  # not needed for these tests
 

--- a/packages/interloper/tests/io/test_partition_row_counts.py
+++ b/packages/interloper/tests/io/test_partition_row_counts.py
@@ -1,0 +1,226 @@
+"""Tests for partition_row_counts across IO backends and Asset."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from interloper_sql import SqliteIO
+
+import interloper as il
+from interloper.io.context import IOContext
+
+# ------------------------------------------------------------------
+# Asset.partition_row_counts
+# ------------------------------------------------------------------
+
+
+class TestAssetPartitionRowCounts:
+    """Tests for Asset.partition_row_counts()."""
+
+    def test_with_sqlite(self):
+        io = SqliteIO(database=":memory:")
+
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io=io)
+
+        p1 = il.TimePartition(dt.date(2025, 1, 1))
+        p2 = il.TimePartition(dt.date(2025, 1, 2))
+        ctx1 = IOContext(asset=asset, partition_or_window=p1)
+        ctx2 = IOContext(asset=asset, partition_or_window=p2)
+        io.write(ctx1, [{"ds": "2025-01-01", "v": 1}, {"ds": "2025-01-01", "v": 2}])
+        io.write(ctx2, [{"ds": "2025-01-02", "v": 3}])
+
+        counts = asset.partition_row_counts()
+        assert counts["2025-01-01"] == 2
+        assert counts["2025-01-02"] == 1
+
+    def test_non_partitioned_raises(self):
+        io = SqliteIO(database=":memory:")
+
+        @il.asset
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return [{"id": 1}]
+
+        asset = my_asset(io=io)
+        with pytest.raises(il.PartitionError, match="not partitioned"):
+            asset.partition_row_counts()
+
+    def test_multi_io_explicit_key(self):
+        io1 = SqliteIO(database=":memory:")
+        io2 = SqliteIO(database=":memory:")
+
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io={"primary": io1, "backup": io2})
+
+        # Write only to primary
+        p1 = il.TimePartition(dt.date(2025, 1, 1))
+        ctx = IOContext(asset=asset, partition_or_window=p1)
+        io1.write(ctx, [{"ds": "2025-01-01", "v": 1}])
+
+        counts = asset.partition_row_counts(io_key="primary")
+        assert counts["2025-01-01"] == 1
+
+    def test_multi_io_invalid_key_raises(self):
+        io = SqliteIO(database=":memory:")
+
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io={"primary": io})
+        with pytest.raises(il.ConfigError, match="IO key 'missing'"):
+            asset.partition_row_counts(io_key="missing")
+
+    def test_empty_table_raises(self):
+        """Table doesn't exist yet — should raise."""
+        io = SqliteIO(database=":memory:")
+
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io=io)
+        with pytest.raises(il.TableNotFoundError):
+            asset.partition_row_counts()
+
+
+# ------------------------------------------------------------------
+# MemoryIO.partition_row_counts
+# ------------------------------------------------------------------
+
+
+class TestMemoryIOPartitionRowCounts:
+    """Tests for MemoryIO.partition_row_counts()."""
+
+    def setup_method(self):
+        """Clear memory storage before each test."""
+        il.MemoryIO.clear()
+
+    def test_counts_partitions(self):
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset()  # defaults to MemoryIO
+
+        p1 = il.TimePartition(dt.date(2025, 1, 1))
+        p2 = il.TimePartition(dt.date(2025, 1, 2))
+        ctx1 = IOContext(asset=asset, partition_or_window=p1)
+        ctx2 = IOContext(asset=asset, partition_or_window=p2)
+        asset.io.write(ctx1, [{"ds": "2025-01-01"}, {"ds": "2025-01-01"}])
+        asset.io.write(ctx2, [{"ds": "2025-01-02"}])
+
+        counts = asset.partition_row_counts()
+        assert counts["2025-01-01"] == 2
+        assert counts["2025-01-02"] == 1
+
+    def test_empty_returns_empty_dict(self):
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset()
+        counts = asset.partition_row_counts()
+        assert counts == {}
+
+
+# ------------------------------------------------------------------
+# FileIO.partition_row_counts
+# ------------------------------------------------------------------
+
+
+class TestFileIOPartitionRowCounts:
+    """Tests for FileIO.partition_row_counts()."""
+
+    def test_counts_partitions(self, tmp_path):
+        io = il.FileIO(str(tmp_path))
+
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io=io)
+
+        p1 = il.TimePartition(dt.date(2025, 1, 1))
+        p2 = il.TimePartition(dt.date(2025, 1, 2))
+        ctx1 = IOContext(asset=asset, partition_or_window=p1)
+        ctx2 = IOContext(asset=asset, partition_or_window=p2)
+        io.write(ctx1, [{"ds": "2025-01-01"}, {"ds": "2025-01-01"}, {"ds": "2025-01-01"}])
+        io.write(ctx2, [{"ds": "2025-01-02"}])
+
+        counts = asset.partition_row_counts()
+        assert counts["2025-01-01"] == 3
+        assert counts["2025-01-02"] == 1
+
+    def test_no_directory_returns_empty(self, tmp_path):
+        io = il.FileIO(str(tmp_path))
+
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io=io)
+        counts = asset.partition_row_counts()
+        assert counts == {}
+
+
+# ------------------------------------------------------------------
+# SqliteIO.partition_row_counts (via DatabaseIO)
+# ------------------------------------------------------------------
+
+
+class TestSqliteIOPartitionRowCounts:
+    """Tests for SqlIO._count_by_partition via SqliteIO."""
+
+    def test_counts_multiple_partitions(self):
+        io = SqliteIO(database=":memory:")
+
+        @il.asset(partitioning=il.TimePartitionConfig(column="ds"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io=io)
+
+        p1 = il.TimePartition(dt.date(2025, 3, 1))
+        p2 = il.TimePartition(dt.date(2025, 3, 2))
+        p3 = il.TimePartition(dt.date(2025, 3, 3))
+        for p, rows in [
+            (p1, [{"ds": "2025-03-01", "v": i} for i in range(5)]),
+            (p2, [{"ds": "2025-03-02", "v": i} for i in range(3)]),
+            (p3, [{"ds": "2025-03-03", "v": 0}]),
+        ]:
+            ctx = IOContext(asset=asset, partition_or_window=p)
+            io.write(ctx, rows)
+
+        counts = asset.partition_row_counts()
+        assert counts == {"2025-03-01": 5, "2025-03-02": 3, "2025-03-03": 1}
+
+    def test_single_partition(self):
+        io = SqliteIO(database=":memory:")
+
+        @il.asset(partitioning=il.PartitionConfig(column="region"))
+        def my_asset(context: il.ExecutionContext) -> list[dict]:
+            return []
+
+        asset = my_asset(io=io)
+
+        ctx = IOContext(asset=asset)
+        io.write(
+            ctx,
+            [
+                {"region": "US", "v": 1},
+                {"region": "US", "v": 2},
+                {"region": "EU", "v": 3},
+            ],
+        )
+
+        counts = asset.partition_row_counts()
+        assert counts["US"] == 2
+        assert counts["EU"] == 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new abstract methods on core IO interfaces and new SQL/BigQuery query paths, which can break custom IO implementations and may surface backend-specific edge cases in grouping/count semantics.
> 
> **Overview**
> Adds an *introspection* API to compute per-partition row counts: `IO.partition_row_counts()` (new abstract method), `DatabaseIO._count_by_partition()`/`partition_row_counts()`, and concrete implementations for `SqlIO`, `BigQueryIO`, `FileIO`, and `MemoryIO`.
> 
> Exposes the feature at the asset level via `Asset.partition_row_counts()` (including multi-IO key resolution), adds a `DAG.backfill()` convenience wrapper, updates the Postgres example to use time-partitioned backfills and print counts, and introduces/updates tests covering the new behavior and error cases (non-partitioned assets, missing tables, invalid IO keys).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5ff3533d2048cbad93af660dc959fa4abe61fa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->